### PR TITLE
Replace SendGrid with Forward Email (SMTP)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,12 +56,12 @@ jobs:
           DOTENV_DB_USERNAME: "${{ vars.DB_USERNAME }}"
           DOTENV_DB_PASSWORD: "${{ secrets.DB_PASSWORD }}"
 
-          DOTENV_MAIL_MAILER: "smtp/sendgrid"
-          DOTENV_MAIL_HOST: smtp.sendgrid.net
-          DOTENV_MAIL_PORT: 465
-          DOTENV_MAIL_ENCRYPTION: ssl
-          DOTENV_MAIL_USERNAME: apikey
-          DOTENV_MAIL_PASSWORD: "${{ secrets.SENDGRID_API_KEY }}"
+          DOTENV_MAIL_MAILER: "${{ vars.MAILER }}"
+          DOTENV_MAIL_HOST: ${{ vars.MAIL_HOST }}
+          DOTENV_MAIL_PORT: ${{ vars.MAIL_PORT }}
+          DOTENV_MAIL_ENCRYPTION: ${{ vars.MAIL_ENCRYPTION }}
+          DOTENV_MAIL_USERNAME: ${{ vars.MAIL_USERNAME }}
+          DOTENV_MAIL_PASSWORD: "${{ secrets.MAIL_PASSWORD }}"
           DOTENV_SENDGRID_API_KEY: "${{ secrets.SENDGRID_API_KEY }}"
 
       - name: Setup Node

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,12 +6,9 @@ use App\Models\PersonalAccessToken;
 use App\Rules\Password;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Sanctum\Sanctum;
-use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
-use Symfony\Component\Mailer\Transport\Dsn;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -37,15 +34,5 @@ class AppServiceProvider extends ServiceProvider
                 Password::min(8)->mixedCase()->numbers()->symbols()->uncompromised()
             );
         }
-
-        Mail::extend('sendgrid', function () {
-            return (new SendgridTransportFactory)->create(
-                new Dsn(
-                    'sendgrid+api',
-                    'default',
-                    config('services.sendgrid.key')
-                )
-            );
-        });
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "propaganistas/laravel-phone": "^6.0",
         "sabre/vobject": "^4.5",
         "symfony/http-client": "^7.0",
-        "symfony/sendgrid-mailer": "^7.0",
         "symfony/yaml": "^7.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f8105d69f5b7ab09e488b5d4d678b1d",
+    "content-hash": "d6bed7b3bcab19a4e129d6046c6d0a7e",
     "packages": [
         {
             "name": "brick/math",
@@ -5746,81 +5746,6 @@
                 }
             ],
             "time": "2025-05-24T20:43:28+00:00"
-        },
-        {
-            "name": "symfony/sendgrid-mailer",
-            "version": "v7.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/sendgrid-mailer.git",
-                "reference": "2c22a2a421fa9e9b335036abe7a519d72b2e8d76"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/sendgrid-mailer/zipball/2c22a2a421fa9e9b335036abe7a519d72b2e8d76",
-                "reference": "2c22a2a421fa9e9b335036abe7a519d72b2e8d76",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/mailer": "^7.2"
-            },
-            "conflict": {
-                "symfony/http-foundation": "<6.4",
-                "symfony/mime": "<6.4",
-                "symfony/webhook": "<7.2"
-            },
-            "require-dev": {
-                "symfony/http-client": "^6.4|^7.0",
-                "symfony/webhook": "^7.2"
-            },
-            "type": "symfony-mailer-bridge",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Mailer\\Bridge\\Sendgrid\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Sendgrid Mailer Bridge",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/sendgrid-mailer/tree/v7.3.2"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-07-10T08:29:33+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/config/mail.php
+++ b/config/mail.php
@@ -36,15 +36,6 @@ return [
 
     'mailers' => [
 
-        'smtp/sendgrid' => [
-            'transport' => 'failover',
-            'mailers' => [
-                'smtp',
-                'sendgrid',
-                'log',
-            ],
-        ],
-
         'smtp' => [
             'transport' => 'smtp',
             'url' => env('MAIL_URL'),
@@ -69,10 +60,6 @@ return [
             // ],
         ],
 
-        'sendgrid' => [
-            'transport' => 'sendgrid',
-        ],
-
         'sendmail' => [
             'transport' => 'sendmail',
             'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -bs -i'),
@@ -90,7 +77,6 @@ return [
         'failover' => [
             'transport' => 'failover',
             'mailers' => [
-                'sendgrid',
                 'smtp',
                 'log',
             ],

--- a/config/services.php
+++ b/config/services.php
@@ -18,10 +18,6 @@ return [
         'token' => env('POSTMARK_TOKEN'),
     ],
 
-    'sendgrid' => [
-        'key' => env('SENDGRID_API_KEY'),
-    ],
-
     'ses' => [
         'key' => env('AWS_ACCESS_KEY_ID'),
         'secret' => env('AWS_SECRET_ACCESS_KEY'),


### PR DESCRIPTION
SendGrid are removing their free tier, so need to migrate to another email provider.